### PR TITLE
Use process.env.PORT

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
 const app = express();
+const PORT = process.env.PORT || 5000;
 
 app.use(cors());
 app.use(express.json());
@@ -31,6 +32,6 @@ app.post('/notes', async (req, res) => {
     res.json(newNote);
 });
 
-app.listen(5000, () => {
+app.listen(PORT, () => {
     console.log('Server is running on port 5000');
 });


### PR DESCRIPTION
Hi , 

I would like to suggest using `const PORT = process.env.PORT  || (port)` as it provides more flexibilty and is frankly a conventional way of defining a server's PORT in Node.js . This is the case due to the fact that `process.env.PORT `checks if there's a pre-defined `PORT` (let's say in `.env`) and if not then it proceeds with the port that is defined explicitly `|| 5000` (fallback). Hosting services like AWS or Heroku usually provide a specific port for an app which is stored in the `PORT` env.variable so using `process.env.PORT` makes even more sense. Of course, it may not be relavant here due to the simplicity of this particular project but doing it almost instinctively is a practice in general.

You're doing a great job ,by the way ! 
Good luck !